### PR TITLE
Don't retry initial_setup, but use a longer timeout

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -195,8 +195,7 @@ resource "terracurl_request" "controller_initial_setup" {
     200,
   ]
 
-  max_retry      = 120
-  retry_interval = 10
+  timeout = 300
 
   lifecycle {
     ignore_changes = all


### PR DESCRIPTION
initial_setup is not generally retryable, and depending on download speed can take a bit of time to respond